### PR TITLE
fix: 디렉토리 구조 리팩토링 및 티켓 데이터 조회 로직 수정

### DIFF
--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -1,6 +1,6 @@
-import CartTotal from './CartTotal';
-import CartIcon from './icons/CartIcon';
-import CartDetail from './CartDetail';
+import CartTotal from '../components/CartTotal';
+import CartIcon from '../components/icons/CartIcon';
+import CartDetail from '../components/CartDetail';
 import { useNavigate } from 'react-router-dom';
 
 export default function Cart() {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import HomeProduct from './HomeProduct';
+import HomeProduct from '../components/HomeProduct';
 import ticketsData from '../testdata/ticket.json'; // JSON 파일 가져오기
 
 export default function Home() {

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import LoginModal from './LoginModal';
+import LoginModal from '../components/LoginModal';
 import People from '../assets/discuss-idea.png';
 
 export default function Login() {

--- a/src/pages/MyOrder.jsx
+++ b/src/pages/MyOrder.jsx
@@ -1,7 +1,7 @@
-import Header from './Header';
-import CartTotal from './CartTotal';
-import CartIcon from './icons/CartIcon';
-import CartDetail from './CartDetail';
+import Header from '../components/Header';
+import CartTotal from '../components/CartTotal';
+import CartIcon from '../components/icons/CartIcon';
+import CartDetail from '../components/CartDetail';
 
 export default function MyOrder() {
   return (

--- a/src/pages/TicketDetail.jsx
+++ b/src/pages/TicketDetail.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import TicketInfo from './TicketInfo';
-import Reviews from './Reviews';
+import TicketInfo from '../components/TicketInfo';
+import Reviews from '../components/Reviews';
 import ticketsData from '../testdata/ticket.json'; // JSON 파일 가져오기
-import ReviewForm from './ReviewForm';
+import ReviewForm from '../components/ReviewForm';
 
 export default function TicketDetail() {
   const { id } = useParams();

--- a/src/pages/TicketDetail.jsx
+++ b/src/pages/TicketDetail.jsx
@@ -12,7 +12,7 @@ export default function TicketDetail() {
 
   useEffect(() => {
     // id에 해당하는 티켓 데이터를 찾습니다.
-    const ticketInfo = ticketsData[id];
+    const ticketInfo = ticketsData.find(ticket => ticket.ticketId === id);
     setTicket(ticketInfo);
   }, [id]);
 

--- a/src/pages/Tickets.jsx
+++ b/src/pages/Tickets.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { getTotalPages, getCurrentItems } from '../utils/pagination';
-import HomeProduct from './HomeProduct';
-import PageButtons from './PageButtons';
+import HomeProduct from '../components/HomeProduct';
+import PageButtons from '../components/PageButtons';
 import ticketsData from '../testdata/ticket.json';
 
 export default function Tickets() {

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,11 +1,11 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from './App';
-import Home from './components/Home';
-import Login from './components/Login';
-import Tickets from './components/Tickets';
-import TicketDetail from './components/TicketDetail';
-import Cart from './components/Cart';
-import MyOrder from './components/MyOrder';
+import Home from './pages/Home';
+import Login from './pages/Login';
+import Tickets from './pages/Tickets';
+import TicketDetail from './pages/TicketDetail';
+import Cart from './pages/Cart';
+import MyOrder from './pages/MyOrder';
 
 export const router = createBrowserRouter([
   {


### PR DESCRIPTION
### 📝 설명
- 파일이 많아지면서 구분하기가 어려워져 디렉토리 구조를 리팩토링했습니다. 또한, 저번 PR에서 tickets.json 안의 형식을 배열로 감싸게 하면서 기존 티켓 데이터 조회 로직을 바꿔야 해서 이를 수정했습니다.

### ⚙️ 작업사항
- 디렉토리 구조 리팩토링 
- 티켓 데이터 조회 로직 수정

### ❗️ 추가 참고 사항
- pages 디렉토리를 하나 더 추가해서 페이지들을 모아놓는 게 어떤지 의견 알려주세요~
  - https://velog.io/@sisofiy626/React-리액트의-폴더-구조
  - 위 블로그 글을 보고 리팩토링했는데 API 연동할 때 되면 파일이 더 많아질 텐데 그때도 해당 블로그 글 보면서 리팩토링하면 도움될 거 같습니다!
